### PR TITLE
Typo in config.yml.example

### DIFF
--- a/etc/config.yml.example
+++ b/etc/config.yml.example
@@ -15,7 +15,7 @@
 ovirt_env_name: engine
 
 # Address or hostname (FQDN) of the Elasticsearch server host
-# If you use oVirt metrics store you cab run:
+# If you use oVirt metrics store you can run:
 # oc get routes
 # and use the logging-es HOST/PORT
 # Example:


### PR DESCRIPTION
There was a typo in  "If you use oVirt metrics store you `cab` run:"