### PR TITLE
Fix the build

### DIFF
--- a/.automation/build-rpm.sh
+++ b/.automation/build-rpm.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -xe
+
+source $(dirname "$(readlink -f "$0")")/build-srpm.sh
+
+# Install build dependencies
+dnf builddep -y rpmbuild/SRPMS/*src.rpm
+
+# Build binary package
+rpmbuild \
+    --define "_topmdir rpmbuild" \
+    --define "_rpmdir rpmbuild" \
+    --rebuild rpmbuild/SRPMS/*src.rpm
+
+# Move RPMs to exported artifacts
+[[ -d $ARTIFACTS_DIR ]] || mkdir -p $ARTIFACTS_DIR
+find rpmbuild -iname \*rpm | xargs mv -t $ARTIFACTS_DIR

--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -xe
+
+# git hash of current commit should be passed as the 1st paraameter
+if [ "${GITHUB_SHA}" == "" ]; then
+  GIT_HASH=$(git rev-list HEAD | wc -l)
+else
+  GIT_HASH=$(git rev-parse --short $GITHUB_SHA)
+fi
+
+SUFFIX=
+# If MILESTONE is empty, it's an official release. Otherwise, add git hash
+grep ^MILESTONE version.mak | grep -q 'MILESTONE=$' || SUFFIX=".git${GIT_HASH}"
+
+# Directory, where build artifacts will be stored, should be passed as the 1st parameter
+ARTIFACTS_DIR=${1:-exported-artifacts}
+
+# Prepare rpmbuild directory
+[[ -d rpmbuild ]] || mkdir -p rpmbuild
+
+# Prepare source archive
+make dist
+
+# Build source package
+rpmbuild \
+    -D "_topdir rpmbuild" \
+    -D "release_suffix ${SUFFIX}" \
+    -ts ovirt-engine-metrics*.tar.gz


### PR DESCRIPTION
Adds proper content to .automation/build-*rpm.sh which are executed from
.copr/Makefile (for COPR based builds) and .github/workflow/build.yml
(for GH action based builds)

Signed-off-by: Martin Perina <mperina@redhat.com>
