### PR TITLE
use GitHub Action: Upload RPMs the oVirt way

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,12 +45,7 @@ jobs:
       run: |
         .automation/build-rpm.sh $ARTIFACTS_DIR
 
-    - name: Create DNF repository
-      run: |
-        createrepo_c $ARTIFACTS_DIR
-
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: ovirt/upload-rpms-action@v2
       with:
-        name: rpm-${{ matrix.shortcut }}
-        path: ${{ env.ARTIFACTS_DIR}}
+        directory: ${{ env.ARTIFACTS_DIR}}


### PR DESCRIPTION
Use oVirt buildcontainer instead of default CentOS Stream container,
because oVirt buildcontainer already contains all required repositories
and build dependencies.

Signed-off-by: Aviv Litman <alitman@redhat.com>